### PR TITLE
[FIXED JENKINS-25446] Make this runnable against 1.580.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <artifactId>flaky-test-handler</artifactId>
   <name>Flaky Test Handler plugin</name>
   <description>Display rerun flaky tests</description>
-  <version>1.0.1</version>
+  <version>1.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Flaky+Test+Handler+Plugin</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.568</version><!-- which version of Jenkins is this plugin built against? Users must have at least this Jenkins version to use this plugin. -->
+    <version>1.580.1</version>
   </parent>
 
   <artifactId>flaky-test-handler</artifactId>
@@ -76,6 +76,11 @@ limitations under the License.
        <groupId>jfree</groupId>
        <artifactId>jfreechart</artifactId>
        <version>1.0.13</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.3</version>
     </dependency>
       <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@ limitations under the License.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.3</version>
+      <version>1.4</version>
     </dependency>
       <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/FlakyTestResultAction.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/FlakyTestResultAction.java
@@ -75,7 +75,7 @@ public class FlakyTestResultAction implements RunAction2 {
    */
   public FlakyTestResultAction(AbstractBuild build, BuildListener listener) {
     this.build = build;
-    AbstractTestResultAction action = build.getTestResultAction();
+    AbstractTestResultAction action = build.getAction(AbstractTestResultAction.class);
     if (action != null) {
       Object latestResult = action.getResult();
       if (latestResult != null && latestResult instanceof TestResult) {

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/FlakyTestResultAction.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/FlakyTestResultAction.java
@@ -75,6 +75,7 @@ public class FlakyTestResultAction implements RunAction2 {
    */
   public FlakyTestResultAction(AbstractBuild build, BuildListener listener) {
     this.build = build;
+    // TODO consider the possibility that there is >1 such action
     AbstractTestResultAction action = build.getAction(AbstractTestResultAction.class);
     if (action != null) {
       Object latestResult = action.getResult();

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataPublisher.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataPublisher.java
@@ -47,6 +47,7 @@ public class JUnitFlakyTestDataPublisher
       BuildListener buildListener, TestResult testResult)
       throws IOException, InterruptedException {
     FlakyTestResult flakyTestResult = new FlakyTestResult(testResult);
+    // TODO consider the possibility that there is >1 such action
     flakyTestResult.freeze(abstractBuild.getAction(AbstractTestResultAction.class), abstractBuild);
     return new JUnitFlakyTestData(flakyTestResult);
   }

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataPublisher.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataPublisher.java
@@ -28,6 +28,7 @@ import hudson.model.Descriptor;
 import hudson.tasks.junit.TestDataPublisher;
 import hudson.tasks.junit.TestResult;
 import hudson.tasks.junit.TestResultAction;
+import hudson.tasks.test.AbstractTestResultAction;
 
 /**
  * Publisher for publishing rerun information
@@ -46,7 +47,7 @@ public class JUnitFlakyTestDataPublisher
       BuildListener buildListener, TestResult testResult)
       throws IOException, InterruptedException {
     FlakyTestResult flakyTestResult = new FlakyTestResult(testResult);
-    flakyTestResult.freeze(abstractBuild.getTestResultAction(), abstractBuild);
+    flakyTestResult.freeze(abstractBuild.getAction(AbstractTestResultAction.class), abstractBuild);
     return new JUnitFlakyTestData(flakyTestResult);
   }
 

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeListener.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeListener.java
@@ -50,6 +50,7 @@ public class DeflakeListener extends RunListener<AbstractBuild> {
   // Add deflake action to the build and aggregate test running stats from this build
   @Override
   public void onCompleted(AbstractBuild build, TaskListener listener) {
+    // TODO consider the possibility that there is >1 such action
     TestResultAction testResultAction = build.getAction(TestResultAction.class);
 
     HistoryAggregatedFlakyTestResultAction historyAction = build.getProject()

--- a/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
@@ -45,6 +45,7 @@ import hudson.plugins.git.extensions.impl.UserExclusion;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.util.StreamTaskListener;
+import jenkins.MasterToSlaveFileCallable;
 
 
 /**
@@ -227,7 +228,7 @@ public abstract class AbstractGitTestCase extends HudsonTestCase {
   }
 
   protected String getHeadRevision(AbstractBuild build, final String branch) throws IOException, InterruptedException {
-    return build.getWorkspace().act(new FilePath.FileCallable<String>() {
+    return build.getWorkspace().act(new MasterToSlaveFileCallable<String>() {
       public String invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
         try {
           ObjectId oid = Git.with(null, null).in(f).getClient().getRepository().resolve("refs/heads/" + branch);


### PR DESCRIPTION
And newer, as noted in [JENKINS-25446](https://issues.jenkins-ci.org/browse/JENKINS-25446).

If you wish to still support weekly builds prior to 1.580.x, the `pom.xml` and `AbstractGitTestCase.java` changes can be reverted; the essential part is the replacement of `AbstractBuild.getTestResultAction()`, which no longer exists after the split of `junit-plugin`.

@reviewbybees