### PR TITLE
FlakyTestResult: catch NullPointerException

### DIFF
--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyTestResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyTestResult.java
@@ -125,6 +125,8 @@ public final class FlakyTestResult extends MetaTabulatedResult {
         e.printStackTrace();
       } catch (InterruptedException e) {
         e.printStackTrace();
+      } catch (NullPointerException e) {
+        e.printStackTrace();
       }
     }
     keepLongStdio = true;


### PR DESCRIPTION
FlakyTestResult(TestResult) should catch `NullPointerException` since File(String) will throw that exception if the input is null (see [File.java:275-277](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/8u40-b25/java/io/File.java#275)).

I've been encountering this repeatedly in some of our builds:

* http://build.osrfoundation.org/job/gazebo-ci-pr_any-homebrew-amd64_flaky/8/console
* http://build.osrfoundation.org/job/gazebo-ci-pr_any-homebrew-amd64_flaky/9/console
* http://build.osrfoundation.org/job/gazebo-ci-pr_any-homebrew-amd64_flaky/10/console

The context and backtrace are:

~~~
Recording test results
ERROR: Build step failed with exception
java.lang.NullPointerException
	at java.io.File.<init>(File.java:277)
	at com.google.jenkins.flakyTestHandler.junit.FlakyTestResult.<init>(FlakyTestResult.java:120)
	at com.google.jenkins.flakyTestHandler.plugin.FlakyTestResultCollector.call(FlakyTestResultCollector.java:15)
	at com.google.jenkins.flakyTestHandler.plugin.FlakyTestResultCollector.call(FlakyTestResultCollector.java:7)
	at hudson.remoting.UserRequest.perform(UserRequest.java:120)
	at hudson.remoting.UserRequest.perform(UserRequest.java:48)
	at hudson.remoting.Request$2.run(Request.java:326)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at hudson.remoting.Engine$1$1.run(Engine.java:62)
	at java.lang.Thread.run(Thread.java:745)
	at ......remote call to t1000.yosemite(Native Method)
	at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1416)
	at hudson.remoting.UserResponse.retrieve(UserRequest.java:220)
	at hudson.remoting.Channel.call(Channel.java:781)
	at com.google.jenkins.flakyTestHandler.plugin.JUnitFlakyTestDataPublisher.getTestData(JUnitFlakyTestDataPublisher.java:49)
	at hudson.tasks.junit.TestDataPublisher.contributeTestData(TestDataPublisher.java:62)
	at hudson.tasks.junit.JUnitResultArchiver.perform(JUnitResultArchiver.java:178)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:75)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:785)
	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:726)
	at hudson.model.Build$BuildExecution.post2(Build.java:185)
	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:671)
	at hudson.model.Run.execute(Run.java:1766)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:408)
Build step 'Publish JUnit test result report' marked build as failure
~~~

There is probably a bug somewhere else, but catching this exception will help with failing more gracefully. The only clue I have to the source of the problem is that is happens with the following set of junit result files:
[flaky_test_results.zip](https://github.com/jenkinsci/flaky-test-handler-plugin/files/210896/flaky_test_results.zip)

Two of those junit files are over 200kb, but I don't know why that would be a problem. Thanks for your time.