### PR TITLE
Float badge annotations to the right

### DIFF
--- a/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyAggregatedTestDataAction/badge.jelly
+++ b/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyAggregatedTestDataAction/badge.jelly
@@ -16,5 +16,5 @@ limitations under the License.
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-   <img src="${rootURL}${it.imagePath}"/> <span> ${it.flaked} tests flaked among all the passing tests </span>
+   <img src="${rootURL}${it.imagePath}"/> <span style="float:right"> ${it.flaked} tests flaked among all the passing tests </span>
 </j:jelly>

--- a/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataAction/badge.jelly
+++ b/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataAction/badge.jelly
@@ -17,12 +17,12 @@ limitations under the License.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <j:if test="${it.isPassed}">
-        <img src="${rootURL}${it.getSmallImagePath(100)}"/> <span>  No flake or failure </span>
+        <img src="${rootURL}${it.getSmallImagePath(100)}"/> <span style="float:right">  No flake or failure </span>
     </j:if>
     <j:if test="${it.isFailed}">
-        <img src="${rootURL}${it.getSmallImagePath(0)}"/> <span>  Failed with ${it.flakyRuns.size()} retries </span>
+        <img src="${rootURL}${it.getSmallImagePath(0)}"/> <span style="float:right">  Failed with ${it.flakyRuns.size()} retries </span>
     </j:if>
     <j:if test="${it.isFlaked}">
-        <img src="${rootURL}${it.getSmallImagePath(80)}"/> <span>  Flaked with ${it.flakyRuns.size()} failures </span>
+        <img src="${rootURL}${it.getSmallImagePath(80)}"/> <span style="float:right">  Flaked with ${it.flakyRuns.size()} failures </span>
     </j:if>
 </j:jelly>


### PR DESCRIPTION
This improves the alignment of the text annotations so it is easier to visually identify flaky results.

This also includes c613eef from #4, so that I can test the plugin artifact generated by the CI.