### PR TITLE
Prevent XSS with Jelly

### DIFF
--- a/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/HistoryAggregatedFlakyTestResultAction/jobMain.jelly
+++ b/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/HistoryAggregatedFlakyTestResultAction/jobMain.jelly
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
      <h2> Flaky History </h2>

--- a/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyAggregatedTestDataAction/badge.jelly
+++ b/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyAggregatedTestDataAction/badge.jelly
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
    <img src="${rootURL}${it.imagePath}"/> <span style="float:right"> ${it.flaked} tests flaked among all the passing tests </span>

--- a/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataAction/badge.jelly
+++ b/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataAction/badge.jelly
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <j:if test="${it.isPassed}">

--- a/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataAction/summary.jelly
+++ b/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataAction/summary.jelly
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <j:if test="${it.isPassed}">

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<?jelly escape-by-default='true'?>
 <div>
   This plugin is used to provide various support for handling flaky tests. It currently supports for Git and Maven.
     It includes support for the latest version of the Maven surefire plug-in which produces additional


### PR DESCRIPTION
This change is recommended to prevent cross-site scripting vulnerabilities:

https://wiki.jenkins.io/display/JENKINS/Jelly+and+XSS+prevention