### PR TITLE
Pipeline support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@ limitations under the License.
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.9.5</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mortbay.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,12 +89,6 @@ limitations under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-      <version>6.1.26</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
       <version>1.24</version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.121.1</jenkins.version>
+    <jenkins.version>2.60.1</jenkins.version>
     <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
     <java.level>8</java.level>
     <!-- <jenkins-test-harness.version>2.13</jenkins-test-harness.version> -->

--- a/pom.xml
+++ b/pom.xml
@@ -17,10 +17,11 @@ limitations under the License.
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580.1</version>
+    <version>3.4</version>
   </parent>
 
   <artifactId>flaky-test-handler</artifactId>
@@ -29,6 +30,15 @@ limitations under the License.
   <version>1.0.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Flaky+Test+Handler+Plugin</url>
+
+  <properties>
+    <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
+    <jenkins.version>2.121.1</jenkins.version>
+    <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
+    <java.level>8</java.level>
+    <!-- <jenkins-test-harness.version>2.13</jenkins-test-harness.version> -->
+    <workflow.version>2.17</workflow.version>
+  </properties>
 
   <developers>
     <developer>
@@ -68,40 +78,47 @@ limitations under the License.
 
   <dependencies>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>17.0</version>
-    </dependency>
-    <dependency>
        <groupId>jfree</groupId>
        <artifactId>jfreechart</artifactId>
        <version>1.0.13</version>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>junit</artifactId>
-      <version>1.4</version>
-    </dependency>
-      <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>git</artifactId>
-      <version>2.2.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>git-client</artifactId>
-      <version>1.9.1</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.9.5</version>
-    </dependency> 
+    </dependency>
     <dependency>
       <groupId>org.mortbay.jetty</groupId>
       <artifactId>jetty-util</artifactId>
       <version>6.1.26</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.24</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>structs</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>annotation-indexer</artifactId>
+      <version>1.12</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <version>3.9.0</version>
+    </dependency>
+    <!-- for workflow support -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>2.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.60.1</jenkins.version>
+    <jenkins.version>2.121.1</jenkins.version>
     <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
     <java.level>8</java.level>
     <!-- <jenkins-test-harness.version>2.13</jenkins-test-harness.version> -->

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyCaseResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyCaseResult.java
@@ -70,7 +70,7 @@ public class FlakyCaseResult extends TestResult implements Comparable<FlakyCaseR
   private final String skippedMessage;
   private final String errorStackTrace;
   private final String errorDetails;
-  private transient FlakySuiteResult parent;
+  private FlakySuiteResult parent;
 
   private transient FlakyClassResult classResult;
 

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyCaseResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyCaseResult.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
@@ -566,6 +567,19 @@ public class FlakyCaseResult extends TestResult implements Comparable<FlakyCaseR
   @Override
   public int compareTo(@Nonnull FlakyCaseResult that) {
     return this.getFullName().compareTo(that.getFullName());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    FlakyCaseResult that = (FlakyCaseResult) o;
+    return Objects.equals(this.getFullName(), that.getFullName());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.getFullName());
   }
 
   @Exported(name="status",visibility=9) // because stapler notices suffix 's' and remove it

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyCaseResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyCaseResult.java
@@ -219,6 +219,9 @@ public class FlakyCaseResult extends TestResult implements Comparable<FlakyCaseR
    * Used to create a fake failure, when Hudson fails to load data from XML files.
    *
    * Public since 1.526.
+   * @param parent suite result
+   * @param testName test name
+   * @param errorStackTrace stack trace
    */
   public FlakyCaseResult(FlakySuiteResult parent, String testName, String errorStackTrace) {
     this.className = parent == null ? "unnamed" : parent.getName();
@@ -331,6 +334,8 @@ public class FlakyCaseResult extends TestResult implements Comparable<FlakyCaseR
 
   /**
    * Gets the class name of a test class.
+   *
+   * @return class name
    */
   @Exported(visibility=9)
   public String getClassName() {
@@ -339,6 +344,8 @@ public class FlakyCaseResult extends TestResult implements Comparable<FlakyCaseR
 
   /**
    * Gets the simple (not qualified) class name.
+   *
+   * @return simple class name
    */
   public String getSimpleName() {
     int idx = className.lastIndexOf('.');
@@ -347,6 +354,8 @@ public class FlakyCaseResult extends TestResult implements Comparable<FlakyCaseR
 
   /**
    * Gets the package name of a test case
+   *
+   * @return package name
    */
   public String getPackageName() {
     int idx = className.lastIndexOf('.');
@@ -360,6 +369,7 @@ public class FlakyCaseResult extends TestResult implements Comparable<FlakyCaseR
 
   /**
    * @since 1.515
+   * @return full display name
    */
   public String getFullDisplayName() {
     return TestNameTransformer.getTransformedName(getFullName());

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyCaseResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyCaseResult.java
@@ -35,6 +35,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 
+import javax.annotation.Nonnull;
+
 import hudson.model.AbstractBuild;
 import hudson.tasks.junit.Messages;
 import hudson.tasks.junit.TestAction;
@@ -561,7 +563,8 @@ public class FlakyCaseResult extends TestResult implements Comparable<FlakyCaseR
     this.parent = parent;
   }
 
-  public int compareTo(FlakyCaseResult that) {
+  @Override
+  public int compareTo(@Nonnull FlakyCaseResult that) {
     return this.getFullName().compareTo(that.getFullName());
   }
 

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyCaseResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyCaseResult.java
@@ -160,8 +160,8 @@ public class FlakyCaseResult extends TestResult implements Comparable<FlakyCaseR
     String head = tx.head(HALF_MAX_SIZE);
     String tail = tx.fastTail(HALF_MAX_SIZE);
 
-    int headBytes = head.getBytes().length;
-    int tailBytes = tail.getBytes().length;
+    int headBytes = head.getBytes("UTF-8").length;
+    int tailBytes = tail.getBytes("UTF-8").length;
 
     middle = len - (headBytes+tailBytes);
     if (middle<=0) {
@@ -587,7 +587,7 @@ public class FlakyCaseResult extends TestResult implements Comparable<FlakyCaseR
     return new JUnitFlakyTestDataAction(getFlakyRuns(), isFailed());
   }
 
-  /*package*/ void setClass(FlakyClassResult classResult) {
+  /*package*/ synchronized void setClass(FlakyClassResult classResult) {
     this.classResult = classResult;
   }
 

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyClassResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyClassResult.java
@@ -23,6 +23,7 @@ import org.kohsuke.stapler.export.Exported;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import hudson.model.AbstractBuild;
 import hudson.tasks.junit.Messages;
@@ -237,6 +238,19 @@ public final class FlakyClassResult extends TabulatedResult implements
 
   public int compareTo(FlakyClassResult that) {
     return this.className.compareTo(that.className);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    FlakyClassResult that = (FlakyClassResult) o;
+    return Objects.equals(className, that.className);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(className);
   }
 
   public String getDisplayName() {

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyClassResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyClassResult.java
@@ -43,6 +43,8 @@ import hudson.tasks.test.TestResult;
 public final class FlakyClassResult extends TabulatedResult implements
     Comparable<FlakyClassResult> , ActionableFlakyTestObject {
 
+  private static final long serialVersionUID = 1;
+
   private final String className; // simple name
   private transient String safeName;
 

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyPackageResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyPackageResult.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 import hudson.model.AbstractBuild;
@@ -305,6 +306,20 @@ public final class FlakyPackageResult extends MetaTabulatedResult implements Com
 
   public int compareTo(FlakyPackageResult that) {
     return this.packageName.compareTo(that.packageName);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    FlakyPackageResult that = (FlakyPackageResult) o;
+    return Objects.equals(packageName, that.packageName);
+  }
+
+  @Override
+  public int hashCode() {
+
+    return Objects.hash(packageName);
   }
 
   public String getDisplayName() {

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyPackageResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyPackageResult.java
@@ -41,6 +41,8 @@ import hudson.tasks.test.TestResult;
  */
 public final class FlakyPackageResult extends MetaTabulatedResult implements Comparable<FlakyPackageResult> {
 
+  private static final long serialVersionUID = 1;
+
   private final String packageName;
   private transient String safeName;
   /**

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakySuiteResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakySuiteResult.java
@@ -274,7 +274,7 @@ public final class FlakySuiteResult implements Serializable {
     if (pr == null) {
       return null;
     }
-    if (pr instanceof hudson.tasks.junit.TestResult) {
+    if (pr instanceof com.google.jenkins.flakyTestHandler.junit.FlakyTestResult) {
       return ((FlakyTestResult) pr).getSuite(name);
     }
     return null;

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakySuiteResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakySuiteResult.java
@@ -224,6 +224,7 @@ public final class FlakySuiteResult implements Serializable {
    *
    * @since 1.281
    * @see CaseResult#getStdout()
+   * @return String with stdout
    */
   @Exported
   public String getStdout() {
@@ -235,13 +236,14 @@ public final class FlakySuiteResult implements Serializable {
    *
    * @since 1.281
    * @see CaseResult#getStderr()
+   * @return String with stderr
    */
   @Exported
   public String getStderr() {
     return stderr;
   }
 
-  /**
+  /*
    * The absolute path to the original test report. OS-dependent.
    */
   public String getFile() {
@@ -284,6 +286,9 @@ public final class FlakySuiteResult implements Serializable {
    *
    * <p>
    * Note that test name needs not be unique.
+   *
+   * @param name name of case
+   * @return flaky case result
    */
   public FlakyCaseResult getCase(String name) {
     return casesByName().get(name);

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyTestResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyTestResult.java
@@ -36,7 +36,7 @@ import java.util.TreeMap;
 
 import hudson.AbortException;
 import hudson.Util;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.tasks.junit.SuiteResult;
 import hudson.tasks.junit.TestResult;
 import hudson.tasks.test.AbstractTestResultAction;
@@ -73,7 +73,7 @@ public final class FlakyTestResult extends MetaTabulatedResult {
   private transient AbstractTestResultAction parentAction;
 
   // set during the freeze phase
-  private transient AbstractBuild owner;
+  private transient Run owner;
 
   private transient TestObject parent;
 
@@ -318,7 +318,7 @@ public final class FlakyTestResult extends MetaTabulatedResult {
   }
 
   @Override
-  public AbstractBuild<?,?> getOwner() {
+  public Run<?,?> getRun() {
     if (parentAction != null) {
       return parentAction.owner;
     } else {
@@ -555,7 +555,7 @@ public final class FlakyTestResult extends MetaTabulatedResult {
    * After the data is frozen, more files can be parsed
    * and then freeze can be called again.
    */
-  public void freeze(AbstractTestResultAction parent, AbstractBuild build) {
+  public void freeze(AbstractTestResultAction parent, Run build) {
     this.parentAction = parent;
     this.owner = build;
     if(suitesByName==null) {

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyTestResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyTestResult.java
@@ -110,9 +110,9 @@ public final class FlakyTestResult extends MetaTabulatedResult {
   private final boolean keepLongStdio;
 
   /**
-   * Construct {@link #FlakyTestResult} from {@link #TestResult}
+   * Construct {@link #FlakyTestResult} from {@link hudson.tasks.junit.TestResult}
    *
-   * @param testResult
+   * @param testResult result of tests
    */
   public FlakyTestResult(TestResult testResult) {
     for (SuiteResult suiteResult : testResult.getSuites()) {
@@ -148,6 +148,10 @@ public final class FlakyTestResult extends MetaTabulatedResult {
   /**
    * Collect reports from the given {@link DirectoryScanner}, while
    * filtering out all files that were created before the given time.
+   *
+   * @param buildTime time of build
+   * @param results directory scanner for result files
+   * @throws IOException throws exception when opening result files fails
    */
   public void parse(long buildTime, DirectoryScanner results) throws IOException {
     String[] includedFiles = results.getIncludedFiles();
@@ -160,6 +164,10 @@ public final class FlakyTestResult extends MetaTabulatedResult {
    * filtering out all files that were created before the given time.
    *
    * @since 1.426
+   * @param buildTime time of build
+   * @param baseDir base directory
+   * @param reportFiles report file names
+   * @throws IOException throws exception when opening result files fails
    */
   public void parse(long buildTime, File baseDir, String[] reportFiles) throws IOException {
 
@@ -196,6 +204,9 @@ public final class FlakyTestResult extends MetaTabulatedResult {
    * Collect reports from the given report files
    *
    * @since 1.500
+   * @param buildTime time of build
+   * @param reportFiles list of report files
+   * @throws IOException throws exception when opening result files fails
    */
   public void parse(long buildTime, Iterable<File> reportFiles) throws IOException {
     boolean parsed=false;
@@ -275,6 +286,9 @@ public final class FlakyTestResult extends MetaTabulatedResult {
 
   /**
    * Parses an additional report file.
+   *
+   * @param reportFile additional report file
+   * @throws IOException throws exception when opening report file fails
    */
   public void parse(File reportFile) throws IOException {
     try {
@@ -365,6 +379,7 @@ public final class FlakyTestResult extends MetaTabulatedResult {
   /**
    * Returns <tt>true</tt> if this doesn't have any any test results.
    * @since 1.511
+   * @return true or false
    */
   @Exported(visibility=999)
   public boolean isEmpty() {

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/FlakyTestResultAction.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/FlakyTestResultAction.java
@@ -27,7 +27,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -35,8 +34,8 @@ import java.util.logging.Logger;
 import hudson.Launcher;
 import hudson.XmlFile;
 import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
 import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
 import hudson.tasks.junit.TestResult;
 import hudson.tasks.test.AbstractTestResultAction;
@@ -71,12 +70,12 @@ public class FlakyTestResultAction implements RunAction2 {
   }
 
   /**
-   * Construct a FlakyTestResultAction object with AbstractBuild and BuildListener
+   * Construct a FlakyTestResultAction object with Run and BuildListener
    *
    * @param build this build
    * @param listener listener of this build
    */
-  public FlakyTestResultAction(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
+  public FlakyTestResultAction(AbstractBuild build, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
     this.build = build;
     // TODO consider the possibility that there is >1 such action
     AbstractTestResultAction action = build.getAction(AbstractTestResultAction.class);
@@ -172,7 +171,7 @@ public class FlakyTestResultAction implements RunAction2 {
   /**
    * Overwrites the {@link FlakyRunStats} by a new data set.
    */
-  public synchronized void setFlakyRunStats(FlakyRunStats stats, BuildListener listener) {
+  public synchronized void setFlakyRunStats(FlakyRunStats stats, TaskListener listener) {
 
     // persist the data
     try {

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/FlakyTestResultAction.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/FlakyTestResultAction.java
@@ -87,7 +87,7 @@ public class FlakyTestResultAction implements RunAction2 {
         if(channel == null) {
           throw new InterruptedException("Could not get channel to run a program remotely.");
         }
-        FlakyTestResult flakyTestResult = launcher.getChannel().call(new FlakyTestResultCollector((TestResult) latestResult));
+        FlakyTestResult flakyTestResult = channel.call(new FlakyTestResultCollector((TestResult) latestResult));
 
         flakyTestResult.freeze(action, build);
         FlakyRunStats stats = new FlakyRunStats(flakyTestResult.getTestFlakyStatsMap());

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/FlakyTestResultAction.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/FlakyTestResultAction.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -81,7 +82,7 @@ public class FlakyTestResultAction implements RunAction2 {
     if (action != null) {
       Object latestResult = action.getResult();
       if (latestResult != null && latestResult instanceof TestResult) {
-        FlakyTestResult flakyTestResult = launcher.getChannel().call(new FlakyTestResultCollector((TestResult) latestResult));
+        FlakyTestResult flakyTestResult = Objects.requireNonNull(launcher.getChannel()).call(new FlakyTestResultCollector((TestResult) latestResult));
 
         flakyTestResult.freeze(action, build);
         FlakyRunStats stats = new FlakyRunStats(flakyTestResult.getTestFlakyStatsMap());

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/HistoryAggregatedFlakyTestResultAction.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/HistoryAggregatedFlakyTestResultAction.java
@@ -37,7 +37,6 @@ import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import jenkins.triggers.SCMTriggerItem;
-import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.Job;
@@ -94,8 +93,8 @@ public class HistoryAggregatedFlakyTestResultAction implements Action {
   void aggregate() {
 
     // set of all the previous builds
-    Stack<AbstractBuild> builds = new Stack<AbstractBuild>();
-    for (AbstractBuild<?, ?> build : project._getRuns().values()) {
+    Stack<Run> builds = new Stack<>();
+    for (Run<?, ?> build : project._getRuns().values()) {
       builds.push(build);
     }
 
@@ -327,7 +326,7 @@ public class HistoryAggregatedFlakyTestResultAction implements Action {
      * build information.
      *
      * @param stats Embedded {@link SingleTestFlakyStats} object
-     * @param build The {@link hudson.model.AbstractBuild} object to get SCM information from.
+     * @param build The {@link hudson.model.Run} object to get SCM information from.
      */
     public SingleTestFlakyStatsWithRevision(SingleTestFlakyStats stats, Run build) {
       this.stats = stats;

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/HistoryAggregatedFlakyTestResultAction.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/HistoryAggregatedFlakyTestResultAction.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.TreeMap;
 
+import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import jenkins.triggers.SCMTriggerItem;
 import hudson.model.AbstractBuild;
@@ -175,7 +176,8 @@ public class HistoryAggregatedFlakyTestResultAction implements Action {
    */
   public static final Function<Map<String, SingleTestFlakyStats>, SingleTestFlakyStats> REVISION_STATS_MAP_TO_AGGREGATED_STATS = new Function<Map<String, SingleTestFlakyStats>, SingleTestFlakyStats>() {
     @Override
-    public SingleTestFlakyStats apply(Map<String, SingleTestFlakyStats> revisionStatsMap) {
+    @Nonnull
+    public SingleTestFlakyStats apply(@Nonnull Map<String, SingleTestFlakyStats> revisionStatsMap) {
       SingleTestFlakyStats aggregatedStatsOverRevision = new SingleTestFlakyStats(0, 0, 0);
 
       for (SingleTestFlakyStats singleTestFlakyStats : revisionStatsMap.values()) {

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/HistoryAggregatedFlakyTestResultAction.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/HistoryAggregatedFlakyTestResultAction.java
@@ -337,7 +337,7 @@ public class HistoryAggregatedFlakyTestResultAction implements Action {
         ArrayList<SCM> scms = new ArrayList<>(s.getSCMs());
         SCM scm = scms.size() > 0 ? scms.get(0) : null;
 
-        if ("hudson.plugins.git.GitSCM".equalsIgnoreCase(scm.getType())) {
+        if (scm != null && "hudson.plugins.git.GitSCM".equalsIgnoreCase(scm.getType())) {
           GitSCM gitSCM = (GitSCM) scm;
           BuildData buildData = gitSCM.getBuildData(build);
           if (buildData != null) {

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataPublisher.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataPublisher.java
@@ -58,7 +58,11 @@ public class JUnitFlakyTestDataPublisher
   @Override
   public TestResultAction.Data getTestData(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, TestResult testResult) {
       try {
-          return contributeTestData(build, null, launcher, null, testResult);
+          FilePath workspace = build.getWorkspace();
+          if (workspace == null) {
+              throw new IOException("no workspace in " + build);
+          }
+          return contributeTestData(build, workspace, launcher, null, testResult);
       } catch (IOException e) {
           throw new IllegalStateException(e);
       } catch (InterruptedException e) {

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataPublisher.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataPublisher.java
@@ -61,21 +61,6 @@ public class JUnitFlakyTestDataPublisher
   }
 
   @Override
-  public TestResultAction.Data getTestData(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, TestResult testResult) {
-      try {
-          FilePath workspace = build.getWorkspace();
-          if (workspace == null) {
-              throw new IOException("no workspace in " + build);
-          }
-          return contributeTestData(build, workspace, launcher, null, testResult);
-      } catch (IOException e) {
-          throw new IllegalStateException(e);
-      } catch (InterruptedException e) {
-          throw new IllegalStateException(e);
-      }
-  }
-
-  @Override
   public DescriptorImpl getDescriptor() {
     return (DescriptorImpl) super.getDescriptor();
   }

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataPublisher.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataPublisher.java
@@ -19,6 +19,7 @@ import com.google.jenkins.flakyTestHandler.junit.FlakyTestResult;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import hudson.Extension;
 import hudson.FilePath;
@@ -48,7 +49,7 @@ public class JUnitFlakyTestDataPublisher
   @Override
   public TestResultAction.Data contributeTestData(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener, TestResult testResult)
       throws IOException, InterruptedException {
-    FlakyTestResult flakyTestResult = launcher.getChannel().call(new FlakyTestResultCollector(testResult));
+    FlakyTestResult flakyTestResult = Objects.requireNonNull(launcher.getChannel()).call(new FlakyTestResultCollector(testResult));
     // TODO consider the possibility that there is >1 such action
     flakyTestResult.freeze(run.getAction(AbstractTestResultAction.class), run);
     return new JUnitFlakyTestData(flakyTestResult);

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeAction.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeAction.java
@@ -34,6 +34,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 
+import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 
 import hudson.model.AbstractProject;
@@ -71,7 +72,8 @@ public class DeflakeAction implements Action {
       CLASS_METHOD_MAP_TO_MAVEN_TESTS_LIST = new Function<Entry<String, Set<String>>, String>() {
 
     @Override
-    public String apply(Entry<String, Set<String>> entry) {
+    @Nonnull
+    public String apply(@Nonnull Entry<String, Set<String>> entry) {
       return entry.getKey() + SHARP + Joiner.on(PLUS).join(entry.getValue());
     }
   };

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeAction.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeAction.java
@@ -19,6 +19,8 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
 import com.google.jenkins.flakyTestHandler.plugin.FlakyTestResultAction;
 
+import hudson.model.Job;
+import hudson.model.Run;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.StaplerRequest;
@@ -34,13 +36,13 @@ import java.util.logging.Level;
 
 import javax.servlet.ServletException;
 
-import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.BooleanParameterValue;
 import hudson.model.CauseAction;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
+import hudson.model.Queue;
 import hudson.model.StringParameterValue;
 import jenkins.model.Jenkins;
 
@@ -106,14 +108,14 @@ public class DeflakeAction implements Action {
    */
   public void doIndex(StaplerRequest request, StaplerResponse response) throws
       IOException, ServletException, InterruptedException {
-    AbstractBuild currentBuild = request.findAncestorObject(AbstractBuild.class);
+    Run currentBuild = request.findAncestorObject(Run.class);
     if (currentBuild != null) {
 
-      AbstractProject project = currentBuild.getProject();
-      if (project == null) {
+      Job job = currentBuild.getParent();
+      if (job == null) {
         return;
       }
-      project.checkPermission(AbstractProject.BUILD);
+      job.checkPermission(AbstractProject.BUILD);
       response.sendRedirect(DEFLAKE_CONFIG_URL);
     }
   }
@@ -124,15 +126,15 @@ public class DeflakeAction implements Action {
   public void doSubmitDeflakeRequest(StaplerRequest request, StaplerResponse response) throws
       IOException, ServletException, InterruptedException {
 
-    AbstractBuild currentBuild = request.findAncestorObject(AbstractBuild.class);
-    if (currentBuild != null) {
-      AbstractProject project = currentBuild.getProject();
-      if (project == null) {
+    Run run = request.findAncestorObject(Run.class);
+    if (run != null) {
+      Job job = run.getParent();
+      if (job == null) {
         response.sendRedirect("../../");
         return;
       }
-      project.checkPermission(AbstractProject.BUILD);
-      List<Action> actions = constructDeflakeCause(currentBuild);
+      job.checkPermission(AbstractProject.BUILD);
+      List<Action> actions = constructDeflakeCause(run);
 
       JSONObject formData = request.getSubmittedForm();
       List<ParameterValue> parameterValues = new ArrayList<ParameterValue>();
@@ -147,13 +149,14 @@ public class DeflakeAction implements Action {
         }
       }
 
-      ParametersAction originalParamAction = currentBuild.getAction(ParametersAction.class);
+      ParametersAction originalParamAction = run.getAction(ParametersAction.class);
       if (originalParamAction == null) {
         originalParamAction = new ParametersAction();
       }
+
       actions.add(originalParamAction.createUpdated(parameterValues));
-      Jenkins.getInstance().getQueue().schedule2(currentBuild.getProject(), 0,
-          actions);
+
+      Jenkins.getInstance().getQueue().schedule((Queue.Task) run.getParent(), 0, actions);
     }
 
     response.sendRedirect("../../");
@@ -177,7 +180,7 @@ public class DeflakeAction implements Action {
    * @return list with all original causes and a {@link hudson.model.Cause.UserIdCause} and a {@link
    * com.google.jenkins.flakyTestHandler.plugin.deflake.DeflakeCause}.
    */
-  private static List<Action> constructDeflakeCause(AbstractBuild up) {
+  private static List<Action> constructDeflakeCause(Run up) {
     List<Action> actions = new ArrayList<Action>();
     actions.add(new CauseAction(new DeflakeCause(up)));
     return actions;

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeAction.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeAction.java
@@ -112,9 +112,6 @@ public class DeflakeAction implements Action {
     if (currentBuild != null) {
 
       Job job = currentBuild.getParent();
-      if (job == null) {
-        return;
-      }
       job.checkPermission(AbstractProject.BUILD);
       response.sendRedirect(DEFLAKE_CONFIG_URL);
     }
@@ -129,10 +126,6 @@ public class DeflakeAction implements Action {
     Run run = request.findAncestorObject(Run.class);
     if (run != null) {
       Job job = run.getParent();
-      if (job == null) {
-        response.sendRedirect("../../");
-        return;
-      }
       job.checkPermission(AbstractProject.BUILD);
       List<Action> actions = constructDeflakeCause(run);
 

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeCause.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeCause.java
@@ -14,8 +14,8 @@
  */
 package com.google.jenkins.flakyTestHandler.plugin.deflake;
 
-import hudson.model.AbstractBuild;
 import hudson.model.Cause;
+import hudson.model.Run;
 
 /**
  * Represents the cause of a deflake build. It is used to communicate with other build actions.
@@ -28,7 +28,7 @@ public class DeflakeCause extends Cause.UpstreamCause {
    * DeflakeCause constructor.
    * @param up upstream failing build which is being deflaked
    */
-  public DeflakeCause(AbstractBuild<?, ?> up) {
+  public DeflakeCause(Run<?, ?> up) {
     super(up);
   }
 

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeGitBuildChooser.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeGitBuildChooser.java
@@ -20,7 +20,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
@@ -32,7 +31,6 @@ import hudson.plugins.git.util.BuildChooserDescriptor;
 import hudson.plugins.git.util.BuildData;
 import hudson.plugins.git.util.DefaultBuildChooser;
 import hudson.remoting.VirtualChannel;
-
 
 /**
  * For a failing build, restore the source code status to the one it failed on and then re-run
@@ -55,15 +53,12 @@ public class DeflakeGitBuildChooser extends BuildChooser {
    * Get failing build revision if this is a deflake build, otherwise use the default build chooser
    */
   @Override
-  public Collection<Revision> getCandidateRevisions(boolean isPollCall, String singleBranch,
-      GitClient git,
-      TaskListener listener, BuildData buildData,
-      BuildChooserContext context)
+  public Collection<Revision> getCandidateRevisions(boolean isPollCall, String singleBranch, GitClient git,
+      TaskListener listener, BuildData buildData, BuildChooserContext context)
       throws GitException, IOException, InterruptedException {
 
-    AbstractBuild build = context.actOnBuild(new GetBuild());
     // Not sure why it cannot be inferred and we have to put cast here
-    DeflakeCause cause = (DeflakeCause) build.getCause(DeflakeCause.class);
+    DeflakeCause cause = (DeflakeCause) context.getBuild().getCause(DeflakeCause.class);
 
     if (cause != null) {
       BuildData gitBuildData = gitSCM.getBuildData(cause.getUpstreamRun(), true);
@@ -75,8 +70,7 @@ public class DeflakeGitBuildChooser extends BuildChooser {
 
     // If it is not a deflake run, then use the default git checkout strategy
     defaultBuildChooser.gitSCM = this.gitSCM;
-    return defaultBuildChooser
-        .getCandidateRevisions(isPollCall, singleBranch, git, listener, buildData, context);
+    return defaultBuildChooser.getCandidateRevisions(isPollCall, singleBranch, git, listener, buildData, context);
   }
 
   @Extension
@@ -92,8 +86,7 @@ public class DeflakeGitBuildChooser extends BuildChooser {
   /**
    * Retrieve build
    */
-  private static class GetBuild
-      implements BuildChooserContext.ContextCallable<AbstractBuild<?, ?>, AbstractBuild> {
+  private static class GetBuild implements BuildChooserContext.ContextCallable<AbstractBuild<?, ?>, AbstractBuild> {
 
     @Override
     public AbstractBuild invoke(AbstractBuild<?, ?> build, VirtualChannel channel) {

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeListener.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeListener.java
@@ -26,8 +26,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import hudson.Extension;
-import hudson.model.AbstractBuild;
+import hudson.model.Action;
 import hudson.model.Cause;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import hudson.tasks.junit.CaseResult;
@@ -39,38 +40,38 @@ import hudson.tasks.junit.TestResultAction;
  * @author Qingzhou Luo
  */
 @Extension
-public class DeflakeListener extends RunListener<AbstractBuild> {
+public class DeflakeListener extends RunListener<Run> {
 
   private static final Logger LOGGER = Logger.getLogger(DeflakeListener.class.getName());
 
   public DeflakeListener() {
-    super(AbstractBuild.class);
+    super(Run.class);
   }
 
   // Add deflake action to the build and aggregate test running stats from this build
   @Override
-  public void onCompleted(AbstractBuild build, TaskListener listener) {
+  public void onCompleted(Run run, TaskListener listener) {
     // TODO consider the possibility that there is >1 such action
-    TestResultAction testResultAction = build.getAction(TestResultAction.class);
+    TestResultAction testResultAction = run.getAction(TestResultAction.class);
 
-    HistoryAggregatedFlakyTestResultAction historyAction = build.getProject()
+    HistoryAggregatedFlakyTestResultAction historyAction = run.getParent()
         .getAction(HistoryAggregatedFlakyTestResultAction.class);
 
     // Aggregate test running results
     if (historyAction != null) {
-      historyAction.aggregateOneBuild(build);
+      historyAction.aggregateOneBuild(run);
     }
 
     if (testResultAction != null && testResultAction.getFailCount() > 0) {
       // Only add deflake action if there are test failures
-      build.addAction(
+      run.addAction(
           new DeflakeAction(getFailingTestClassMethodMap(testResultAction.getFailedTests())));
     }
   }
 
   // Set the name of a deflake build
   @Override
-  public void onStarted(AbstractBuild build, TaskListener listener) {
+  public void onStarted(Run build, TaskListener listener) {
     List<Cause> causesList = build.getCauses();
     try {
       for (Cause cause : causesList) {

--- a/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/HistoryAggregatedFlakyTestResultAction/jobMain.jelly
+++ b/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/HistoryAggregatedFlakyTestResultAction/jobMain.jelly
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
      <h2> Flaky History </h2>

--- a/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyAggregatedTestDataAction/badge.jelly
+++ b/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyAggregatedTestDataAction/badge.jelly
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
    <img src="${rootURL}${it.imagePath}"/> <span style="float:right"> ${it.flaked} tests flaked among all the passing tests </span>

--- a/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataAction/badge.jelly
+++ b/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataAction/badge.jelly
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <j:if test="${it.isPassed}">

--- a/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataAction/summary.jelly
+++ b/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/JUnitFlakyTestDataAction/summary.jelly
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <j:if test="${it.isPassed}">

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<?jelly escape-by-default='true'?>
 <div>
   This plugin is used to provide various support for handling flaky tests. It currently supports for Git and Maven.
     It includes support for the latest version of the Maven surefire plug-in which produces additional

--- a/src/test/java/com/google/jenkins/flakyTestHandler/plugin/HistoryAggregatedFlakyTestResultActionTest.java
+++ b/src/test/java/com/google/jenkins/flakyTestHandler/plugin/HistoryAggregatedFlakyTestResultActionTest.java
@@ -29,6 +29,7 @@ import com.google.jenkins.flakyTestHandler.plugin.HistoryAggregatedFlakyTestResu
 import com.google.jenkins.flakyTestHandler.plugin.HistoryAggregatedFlakyTestResultAction.SingleTestFlakyStatsWithRevision;
 import com.google.jenkins.flakyTestHandler.plugin.deflake.DeflakeCause;
 
+import hudson.model.Run;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -38,7 +39,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import hudson.model.AbstractBuild;
 import hudson.model.CauseAction;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -67,19 +67,19 @@ public class HistoryAggregatedFlakyTestResultActionTest {
 
     FreeStyleProject project = jenkins.createFreeStyleProject("project");
 
-    List<AbstractBuild> buildList = new ArrayList<AbstractBuild>();
+    List<Run> runList = new ArrayList<>();
 
     for (FlakyTestResultAction action : setUpFlakyTestResultAction()) {
       FreeStyleBuild build = new FreeStyleBuild(project);
       build.addAction(action);
-      buildList.add(build);
+      runList.add(build);
     }
 
     HistoryAggregatedFlakyTestResultAction action = new HistoryAggregatedFlakyTestResultAction(
         null);
 
-    for (AbstractBuild build : buildList) {
-      action.aggregateOneBuild(build);
+    for (Run run : runList) {
+      action.aggregateOneBuild(run);
     }
 
     Map<String, Map<String, SingleTestFlakyStats>> statsMapOverRevision =
@@ -147,14 +147,14 @@ public class HistoryAggregatedFlakyTestResultActionTest {
         flakyTestResultActions);
 
     // First non-deflake build
-    AbstractBuild firstBuild = (AbstractBuild) project
+    Run firstBuild = project
         .scheduleBuild2(0, flakyTestResultActionList.get(0)).get();
     while (firstBuild.isBuilding()) {
       Thread.sleep(100);
     }
 
     // Second deflake build
-    AbstractBuild secondBuild = (AbstractBuild) project
+    Run secondBuild = project
         .scheduleBuild2(0, flakyTestResultActionList.get(1),
             new CauseAction(new DeflakeCause(firstBuild))).get();
     while (secondBuild.isBuilding()) {
@@ -162,7 +162,7 @@ public class HistoryAggregatedFlakyTestResultActionTest {
     }
 
     // Third deflake build with HistoryAggregatedFlakyTestResultAction
-    AbstractBuild thirdBuild = (AbstractBuild) project
+    Run thirdBuild = project
         .scheduleBuild2(0, flakyTestResultActionList.get(2),
             new HistoryAggregatedFlakyTestResultAction(project)).get();
     while (thirdBuild.isBuilding()) {


### PR DESCRIPTION
Includes:
* Update dependencies and parent version for Jenkins plugins
* Replace deprecated `AbstractBuild.getProject` with pipeline-compatible `Run.getParent` according to https://jenkins.io/doc/developer/plugin-development/pipeline-integration/#more-general-apis
* Adapt to the fact that pipelines can have multiple SCMs instead of former builds (who had only one). See https://jenkins.io/doc/developer/plugin-development/pipeline-integration/#scms
* Adapt to TestDataPublisher of JUnit. I used the junit jenkins plugin as guideline: https://github.com/jenkinsci/junit-plugin/blob/master/src/main/java/hudson/tasks/junit/TestDataPublisher.java#L49
* Add test case for deflake action in pipeline 