### PR TITLE
Enable onlyRunFailingTests checkbox by default

### DIFF
--- a/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeAction/deflakeConfig.jelly
+++ b/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeAction/deflakeConfig.jelly
@@ -35,7 +35,7 @@ limitations under the License.
                  <f:entry title="only run failing tests" field="only-failing" description="Whether to run only failing tests" help="/plugin/flaky-test-handler/help-only-fail.html">
                  <div name="testParam" description="Whether only run failing tests">
                      <input type="hidden" name="name" value="onlyRunFailingTests" />
-                     <f:checkbox name="value" checked="false" />
+                     <f:checkbox name="value" checked="true" />
                  </div>
                  </f:entry>
 


### PR DESCRIPTION
This will mark the checkbox "only run failing tests" by default. I never understood why it is unchecked in the first place.

<img width="244" alt="Screenshot 2021-07-12 at 17 56 37" src="https://user-images.githubusercontent.com/1278296/125318894-91e14500-e33a-11eb-99da-97622c2b15c4.png">
