### PR TITLE
Update to recommended plugin-pom and jenkins version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,7 @@ limitations under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.263.1</jenkins.version>
-    <no-test-jar>false</no-test-jar>
+    <jenkins.version>2.277.1</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,6 @@ limitations under the License.
       <groupId>org.kohsuke</groupId>
       <artifactId>access-modifier-suppressions</artifactId>
       <version>1.16</version>
-      <scope>test</scope>
     </dependency>
     <!-- for workflow support -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -109,9 +109,16 @@ limitations under the License.
       <version>3.9.0</version>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+      <version>1.77</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>access-modifier-suppressions</artifactId>
       <version>1.16</version>
+      <scope>test</scope>
     </dependency>
     <!-- for workflow support -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.4</version>
+    <version>4.19</version>
   </parent>
 
   <artifactId>flaky-test-handler</artifactId>
@@ -32,12 +32,10 @@ limitations under the License.
   <url>https://github.com/jenkinsci/flaky-test-handler-plugin</url>
 
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.121.1</jenkins.version>
-    <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
+    <jenkins.version>2.277.1</jenkins.version>
     <java.level>8</java.level>
-    <!-- <jenkins-test-harness.version>2.13</jenkins-test-harness.version> -->
-    <workflow.version>2.17</workflow.version>
   </properties>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@ limitations under the License.
       <artifactId>git</artifactId>
       <version>3.9.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>access-modifier-suppressions</artifactId>
+      <version>1.16</version>
+    </dependency>
     <!-- for workflow support -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,8 @@ limitations under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.277.1</jenkins.version>
+    <jenkins.version>2.263.1</jenkins.version>
+    <no-test-jar>false</no-test-jar>
     <java.level>8</java.level>
   </properties>
 

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyCaseResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyCaseResult.java
@@ -22,6 +22,7 @@ import com.google.jenkins.flakyTestHandler.plugin.JUnitFlakyTestDataAction;
 import org.apache.commons.io.FileUtils;
 import org.dom4j.Element;
 import org.jvnet.localizer.Localizable;
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 import org.kohsuke.stapler.export.Exported;
 
 import java.io.File;
@@ -615,6 +616,7 @@ public class FlakyCaseResult extends TestResult implements Comparable<FlakyCaseR
   /**
    * Constants that represent the status of this test.
    */
+  @SuppressRestrictedWarnings(Messages.class)
   public enum Status {
     /**
      * This test runs OK, just like its previous run.

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyClassResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyClassResult.java
@@ -16,6 +16,7 @@ package com.google.jenkins.flakyTestHandler.junit;
 
 import com.google.jenkins.flakyTestHandler.plugin.JUnitFlakyAggregatedTestDataAction;
 
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
@@ -104,6 +105,7 @@ public final class FlakyClassResult extends TabulatedResult implements
     return null;
   }
 
+  @SuppressRestrictedWarnings(Messages.class)
   public String getTitle() {
     return Messages.ClassResult_getTitle(getDisplayName());
   }

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyPackageResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyPackageResult.java
@@ -14,6 +14,7 @@
  */
 package com.google.jenkins.flakyTestHandler.junit;
 
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
@@ -114,11 +115,13 @@ public final class FlakyPackageResult extends MetaTabulatedResult implements Com
   }
 
   @Override
+  @SuppressRestrictedWarnings(Messages.class)
   public String getTitle() {
     return Messages.PackageResult_getTitle(getDisplayName());
   }
 
   @Override
+  @SuppressRestrictedWarnings(Messages.class)
   public String getChildTitle() {
     return Messages.PackageResult_getChildTitle();
   }


### PR DESCRIPTION
I'm currently trying to tackle https://issues.jenkins.io/browse/JENKINS-61263 For this it would be good to have a newer version of the plugin pom and Jenkins around. According to [this](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions) the current recommended Jenkins version is 2.277.1 and according to [this](https://github.com/jenkinsci/plugin-pom#usage) we should use the latest version of the plugin pom.

I needed to add two dependencies to fix the tests afterwards:
* script-security was added for test scope because the tests complained that the Script Security Plugin was too old
* access-modifier-suppressions was added to suppress the errors regarding our direct usage of Messages.class from junit