### PR TITLE
[JENKINS-66126] Fix flakiness indicator sometimes missing in aggregated test data

### DIFF
--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyClassResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyClassResult.java
@@ -214,23 +214,8 @@ public final class FlakyClassResult extends TabulatedResult implements
     }
   }
 
-
   void freeze() {
-    passCount = failCount = skipCount = flakeCount = 0;
-    duration = 0;
-    for (FlakyCaseResult r : cases) {
-      r.setClass(this);
-      if (r.isSkipped()) {
-        skipCount++;
-      } else if (r.isFlaked()) {
-        flakeCount++;
-      } else if (r.isPassed()) {
-        passCount++;
-      } else {
-        failCount++;
-      }
-      duration += r.getDuration();
-    }
+    this.tally();
     Collections.sort(cases);
   }
 

--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyPackageResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyPackageResult.java
@@ -19,13 +19,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.TreeMap;
+import java.util.*;
 
 import hudson.model.AbstractBuild;
 import hudson.tasks.junit.Messages;
@@ -79,10 +73,7 @@ public final class FlakyPackageResult extends MetaTabulatedResult implements Com
     if (safeName != null) {
       return safeName;
     }
-    Collection<FlakyPackageResult> siblings = (parent == null ? Collections.EMPTY_LIST : parent.getChildren());
-    return safeName = uniquifyName(
-        siblings,
-        safe(getName()));
+    return safeName = safe(getName());
   }
 
   @Override


### PR DESCRIPTION
Fixes https://issues.jenkins.io/browse/JENKINS-66126 by not using the uniquify method of junit for the package name. A package name should be unique enough anyway.