### PR TITLE
Parse result files only once, even if they contain multiple suites

### DIFF
--- a/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyTestResult.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakyTestResult.java
@@ -30,8 +30,10 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import hudson.AbortException;
@@ -115,9 +117,15 @@ public final class FlakyTestResult extends MetaTabulatedResult {
    * @param testResult result of tests
    */
   public FlakyTestResult(TestResult testResult) {
+
+    Set<String> resultFiles = new HashSet<>();
     for (SuiteResult suiteResult : testResult.getSuites()) {
+      resultFiles.add(suiteResult.getFile());
+    }
+
+    for (String resultFile : resultFiles) {
       try {
-        suites.addAll(FlakySuiteResult.parse(new File(suiteResult.getFile()), true));
+        suites.addAll(FlakySuiteResult.parse(new File(resultFile), true));
         testResultInstance = testResult;
       } catch (DocumentException e) {
         e.printStackTrace();


### PR DESCRIPTION
The plugin currently expects 1 suite per resultfile. However a result file may contain multiple, even many suites. This led to a OOME in our pipeline, when trying to use the plugin as-is in the publishing step.
Deriving the actual list of result files before running the parse loop resolves that issue and should not affect the current plugin behavior.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira (no issue created)
- [x] Link to relevant pull requests, esp. upstream and downstream changes (no relevant pull requests)
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue: Created a hprof from the faulty behavior and verified the plugin works correctly after fixing it, by including it in our pipeline. If anything else is needed, please just ask.

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
