### PR TITLE
Update to Jenkins's new table style

### DIFF
--- a/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/HistoryAggregatedFlakyTestResultAction/jobMain.jelly
+++ b/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/HistoryAggregatedFlakyTestResultAction/jobMain.jelly
@@ -23,12 +23,12 @@ limitations under the License.
          <j:otherwise>(${%Only show flaky tests})</j:otherwise>
        </j:choose>
      </a>
-     <table class="pane sortable bigtable" id="flakyStats">
+     <table class="jenkins-table sortable" id="flakyStats">
        <tr>
-         <td class="pane-header" style="width:15em">${%Test Name}</td>
-         <td class="pane-header" style="width:5em">${%Passes}</td>
-         <td class="pane-header" style="width:5em">${%Fails}</td>
-         <td class="pane-header" style="width:5em">${%Flakes}</td>
+         <th class="pane-header">${%Test Name}</th>
+         <th class="pane-header" style="width:3em">${%Passes}</th>
+         <th class="pane-header" style="width:3em">${%Fails}</th>
+         <th class="pane-header" style="width:3em">${%Flakes}</th>
        </tr>
        <tbody>
          <j:forEach var="entry" items="${it.filteredAggregatedFlakyStats.entrySet()}">

--- a/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/TestFlakyStatsOverRevision/index.jelly
+++ b/src/main/resources/com/google/jenkins/flakyTestHandler/plugin/TestFlakyStatsOverRevision/index.jelly
@@ -26,12 +26,12 @@ limitations under the License.
     </j:invoke>
     <h2> ${testName}</h2>
 
-     <table class="pane sortable bigtable" id="testStatsOverRevision">
+     <table class="jenkins-table sortable" id="testStatsOverRevision">
        <tr>
-         <td class="pane-header" style="width:4em">${%Rev Number}</td>
-         <td class="pane-header" style="width:10em">${%Revision}</td>
-         <td class="pane-header" style="width:4em">${%Passes}</td>
-         <td class="pane-header" style="width:4em">${%Fails}</td>
+         <th class="pane-header" style="width:4em">${%Rev Number}</th>
+         <th class="pane-header" style="width:10em">${%Revision}</th>
+         <th class="pane-header" style="width:3em">${%Passes}</th>
+         <th class="pane-header" style="width:3em">${%Fails}</th>
        </tr>
        <tbody>
          <j:set var="count" value="1"/>
@@ -42,11 +42,9 @@ limitations under the License.
              <td class="pane" style="text-align:left" data="${count}">
                 <j:out value="Rev #${count}"/>
              </td>
-             <td class="pane" style="text-align:left">
-                <j:out value="${revision}"/>
-             </td>
-             <td class="pane" style="text-align:left" data="${stat.pass}">${stat.pass}</td>
-             <td class="pane" style="text-align:left" data="${stat.fail}">${stat.fail}</td>
+             <td class="pane" style="text-align:left">${revision}</td>
+             <td class="pane" style="text-align:right" data="${stat.pass}">${stat.pass}</td>
+             <td class="pane" style="text-align:right" data="${stat.fail}">${stat.fail}</td>
            </tr>
          <j:set var="count" value="${count + 1}"/>
          </j:forEach>


### PR DESCRIPTION
The old tables had a very dark table header. With this PR the header is now light gray like on the other tables.