### PR TITLE
Show which user has caused the manual deflaking

### DIFF
--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeAction.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeAction.java
@@ -19,8 +19,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
 import com.google.jenkins.flakyTestHandler.plugin.FlakyTestResultAction;
 
-import hudson.model.Job;
-import hudson.model.Run;
+import hudson.model.*;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -38,14 +37,6 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 
-import hudson.model.AbstractProject;
-import hudson.model.Action;
-import hudson.model.BooleanParameterValue;
-import hudson.model.CauseAction;
-import hudson.model.ParameterValue;
-import hudson.model.ParametersAction;
-import hudson.model.Queue;
-import hudson.model.StringParameterValue;
 import jenkins.model.Jenkins;
 
 /**
@@ -171,15 +162,15 @@ public class DeflakeAction implements Action {
   }
 
   /**
-   * Construct a list of actions which contain deflake cause and the original failed build
+   * Construct a list of actions which contain the user and deflake cause and the original failed build
    *
    * @param up upstream build
    * @return list with all original causes and a {@link hudson.model.Cause.UserIdCause} and a {@link
    * com.google.jenkins.flakyTestHandler.plugin.deflake.DeflakeCause}.
    */
   private static List<Action> constructDeflakeCause(Run up) {
-    List<Action> actions = new ArrayList<Action>();
-    actions.add(new CauseAction(new DeflakeCause(up)));
+    List<Action> actions = new ArrayList<>();
+    actions.add(new CauseAction(new Cause.UserIdCause(), new DeflakeCause(up)));
     return actions;
   }
 


### PR DESCRIPTION
This shows which use has pressed the deflake action button and started the deflake in the build history:

![cause](https://github.com/user-attachments/assets/bd34b7bf-1863-45b4-8de5-cf13a2289cbf)

### Testing done

Manual test done via `mvn hpi:run`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
