### PR TITLE
fix: Show button also when job-specific permissions are used

### DIFF
--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeAction.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeAction.java
@@ -61,24 +61,27 @@ public class DeflakeAction implements Action {
   private static final String PLUS = "+";
 
   private static final Function<Map.Entry<String, Set<String>>, String>
-      CLASS_METHOD_MAP_TO_MAVEN_TESTS_LIST = new Function<Entry<String, Set<String>>, String>() {
+          CLASS_METHOD_MAP_TO_MAVEN_TESTS_LIST = new Function<>() {
 
-    @Override
-    @Nonnull
-    public String apply(@Nonnull Entry<String, Set<String>> entry) {
-      return entry.getKey() + SHARP + Joiner.on(PLUS).join(entry.getValue());
-    }
+      @Override
+      @Nonnull
+      public String apply(@Nonnull Entry<String, Set<String>> entry) {
+          return entry.getKey() + SHARP + Joiner.on(PLUS).join(entry.getValue());
+      }
   };
 
   private final Map<String, Set<String>> failingClassMethodMap;
 
-  public DeflakeAction(Map<String, Set<String>> failingClassMethodMap) {
+  private final Run run;
+
+  public DeflakeAction(Run run, Map<String, Set<String>> failingClassMethodMap) {
+    this.run = run;
     this.failingClassMethodMap = failingClassMethodMap;
   }
 
   @Override
   public String getIconFileName() {
-    if (Jenkins.get().hasPermission(Item.BUILD)) {
+    if (Jenkins.get().hasPermission(Item.BUILD) || run.getParent().hasPermission(Item.BUILD)) {
       return "clock.png";
     }
     return null;
@@ -86,7 +89,7 @@ public class DeflakeAction implements Action {
 
   @Override
   public String getDisplayName() {
-    if (Jenkins.get().hasPermission(Item.BUILD)) {
+    if (Jenkins.get().hasPermission(Item.BUILD) || run.getParent().hasPermission(Item.BUILD)) {
       return "Deflake this build";
     }
     return null;
@@ -94,7 +97,7 @@ public class DeflakeAction implements Action {
 
   @Override
   public String getUrlName() {
-    if (Jenkins.get().hasPermission(Item.BUILD)) {
+    if (Jenkins.get().hasPermission(Item.BUILD) || run.getParent().hasPermission(Item.BUILD)) {
       return "deflake";
     }
     return null;

--- a/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeListener.java
+++ b/src/main/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeListener.java
@@ -65,7 +65,7 @@ public class DeflakeListener extends RunListener<Run> {
     if (testResultAction != null && testResultAction.getFailCount() > 0) {
       // Only add deflake action if there are test failures
       run.addAction(
-          new DeflakeAction(getFailingTestClassMethodMap(testResultAction.getFailedTests())));
+          new DeflakeAction(run, getFailingTestClassMethodMap(testResultAction.getFailedTests())));
     }
   }
 

--- a/src/test/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeActionTest.java
+++ b/src/test/java/com/google/jenkins/flakyTestHandler/plugin/deflake/DeflakeActionTest.java
@@ -18,12 +18,14 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.Sets;
 
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
+import java.io.IOException;
+import java.util.*;
 
 public class DeflakeActionTest {
 
@@ -34,8 +36,11 @@ public class DeflakeActionTest {
   private final static String TEST_METHOD_TWO = "methodTwo";
   private final static String TEST_METHOD_THREE = "methodThree";
 
+  @Rule
+  public JenkinsRule jenkins = new JenkinsRule();
+
   @Test
-  public void testGenerateMavenTestParamsForSingleTest() {
+  public void testGenerateMavenTestParamsForSingleTest() throws IOException {
     Map<String, Set<String>> classMethodMap = new LinkedHashMap<String, Set<String>>();
     classMethodMap.put(TEST_CLASS_TWO, Sets.newHashSet(TEST_METHOD_THREE));
     testGenerateMavenTestParams(classMethodMap, "classTwo#methodThree",
@@ -43,7 +48,7 @@ public class DeflakeActionTest {
   }
 
   @Test
-  public void testGenerateMavenTestParamsForMultipleTests() {
+  public void testGenerateMavenTestParamsForMultipleTests() throws IOException {
     Map<String, Set<String>> classMethodMap = new LinkedHashMap<String, Set<String>>();
     classMethodMap.put(TEST_CLASS_ONE,
         Sets.newLinkedHashSet(Arrays.asList(TEST_METHOD_ONE, TEST_METHOD_TWO)));
@@ -53,8 +58,10 @@ public class DeflakeActionTest {
   }
 
   private void testGenerateMavenTestParams(Map<String, Set<String>> classMethodMap,
-      String expectedTestParam, String errorMsg) {
-    DeflakeAction action = new DeflakeAction(classMethodMap);
+                                           String expectedTestParam, String errorMsg) throws IOException {
+    FreeStyleProject project = jenkins.createFreeStyleProject("project");
+    FreeStyleBuild build = new FreeStyleBuild(project);
+    DeflakeAction action = new DeflakeAction(build, classMethodMap);
     assertEquals(errorMsg, expectedTestParam,
         action.generateMavenTestParams());
   }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

@piyugit reported that they experiencing issues with the latest version of the Flaky Tests plugin due to the "Deflake this build" option no longer being visible on jobs with job-specific permissions. I try to not only check Jenkins.get().hasPermission(Item.BUILD) but also run.getParent().hasPermission(Item.BUILD) now which should give me the job (job is parent of run) and then check for permissions there.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
